### PR TITLE
Bugfix/issue 25

### DIFF
--- a/database/factories/ProjectFactory.php
+++ b/database/factories/ProjectFactory.php
@@ -17,7 +17,7 @@ class ProjectFactory extends Factory
     public function definition(): array
     {
         return [
-            //
+            'name' => fake()->words(3, true),
         ];
     }
 }

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -27,8 +27,8 @@
 
         <!-- Remember Me -->
         <div class="mb-3 form-check">
-            <input type="checkbox" class="form-check-input" name="remember_me" id="remember-me">
-            <label class="form-check-label" for="remember-me">{{ __('rememberMe') }}</label>
+            <input type="checkbox" class="form-check-input" name="remembere" id="remember">
+            <label class="form-check-label" for="remember">{{ __('rememberMe') }}</label>
         </div>
 
         <div class="d-flex justify-content-between align-items-center">


### PR DESCRIPTION
Fix for issue #25 

The problem are:
The input has the name as `remember_me` but on request, you get via `remember`.
Files:
`resources/views/auth/login.blade.php:30`
`app/Http/Requests/Auth/LoginRequest.php:44`

![image](https://github.com/alextselegidis/timecrack/assets/8310974/c6068e9c-b45f-401e-b58e-92cfab136fc7)
![image](https://github.com/alextselegidis/timecrack/assets/8310974/81ce6e87-1f88-44ba-85d3-f5c827a0a48c)
